### PR TITLE
Fix bug: unregister the application before unregister objects, or you…

### DIFF
--- a/src/Linux.Bluetooth/GattServer/GattServer.cs
+++ b/src/Linux.Bluetooth/GattServer/GattServer.cs
@@ -107,6 +107,9 @@
     {
       if (_gattApplication is not null)
       {
+        // unregister the application before unregister objects
+        await _gattManager.UnregisterApplicationAsync(_gattApplication.ObjectPath);
+
         foreach (GattService service in _gattApplication.Services)
         {
           foreach (GattCharacteristicServer characteristic in service.Characteristics)
@@ -119,7 +122,6 @@
 
         Connection.UnregisterObjects(_gattApplication.Services);
 
-        await _gattManager.UnregisterApplicationAsync(_gattApplication.ObjectPath);
         _gattApplication = null;
       }
     }
@@ -153,6 +155,6 @@
         _advertisement = null;
       }
     }
-    
+
   }
 }


### PR DESCRIPTION

# Bug: Exception Thrown When Unregistering GATT Application in Incorrect Order


## Details

Unregistering the GATT application in the GattServer class throws an exception when the unregistration order is incorrect. The issue occurs because the application is being unregistered after its objects have already been removed from the D-Bus connection.

### Exception Details:

```C#
Error unregistering GATT application: Tmds.DBus.DBusException: org.freedesktop.DBus.Error.UnknownObject: Method "UnregisterApplication" with signature "o" on interface "org.bluez.GattManager1" doesn't exist

   at Tmds.DBus.DBusConnection.CallMethodAsync(Message msg, Boolean checkConnected, Boolean checkReplyType)
   at Tmds.DBus.Connection.CallMethodAsync(Message message)
   at Tmds.DBus.CodeGen.DBusObjectProxy.SendMethodReturnReaderAsync(String iface, String member, Nullable`1 inSignature, MessageWriter writer)
```

### Root Cause:

The call to UnregisterApplicationAsync() is made after the GATT objects (services, characteristics, descriptors) have already been unregistered from the D-Bus connection. This causes BlueZ to throw an UnknownObject error because the application path no longer exists.

## Linked To Issue/Feature

[* #65 - _issue/discussion_](https://github.com/SuessLabs/Linux.Bluetooth/issues/65)

