### PR TITLE
Enhancement: Implement Agent to manage incoming Bluetooth connections

### DIFF
--- a/Linux.Bluetooth.sln
+++ b/Linux.Bluetooth.sln
@@ -36,6 +36,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "GUI", "GUI", "{1A8CDB9B-703
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BleServerCli", "samples\BleServerCli\BleServerCli.csproj", "{A2947B49-83D1-4B32-8BA5-19895190F668}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AgentExample", "samples\AgentExample\AgentExample.csproj", "{7F78DFF5-F9BA-47D0-A21B-005857EA0AD2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -78,6 +80,10 @@ Global
 		{A2947B49-83D1-4B32-8BA5-19895190F668}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A2947B49-83D1-4B32-8BA5-19895190F668}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A2947B49-83D1-4B32-8BA5-19895190F668}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7F78DFF5-F9BA-47D0-A21B-005857EA0AD2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7F78DFF5-F9BA-47D0-A21B-005857EA0AD2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7F78DFF5-F9BA-47D0-A21B-005857EA0AD2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7F78DFF5-F9BA-47D0-A21B-005857EA0AD2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -92,6 +98,7 @@ Global
 		{E2918579-E426-4FF9-87D4-A571C71BA0A5} = {1A8CDB9B-703B-48AC-B196-A3A0358E635B}
 		{1A8CDB9B-703B-48AC-B196-A3A0358E635B} = {8DCF476D-3F5A-4228-BE63-B7D6D9E5F629}
 		{A2947B49-83D1-4B32-8BA5-19895190F668} = {8DCF476D-3F5A-4228-BE63-B7D6D9E5F629}
+		{7F78DFF5-F9BA-47D0-A21B-005857EA0AD2} = {8DCF476D-3F5A-4228-BE63-B7D6D9E5F629}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {00669A67-D800-45CB-8AF3-2B4EB823A37C}

--- a/samples/AgentExample/AgentExample.csproj
+++ b/samples/AgentExample/AgentExample.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Linux.Bluetooth\Linux.Bluetooth.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/samples/AgentExample/Program.cs
+++ b/samples/AgentExample/Program.cs
@@ -1,0 +1,134 @@
+﻿// This example demonstrates how to use a Bluetooth agent to manage incoming device connections.
+// When another device initiates a connection, the current device handles the pairing process
+// and automatically marks the device as trusted.
+
+using Linux.Bluetooth;
+using Linux.Bluetooth.Extensions;
+using Tmds.DBus;
+
+public class AgentExample
+{
+  public static async Task Main(string[] args)
+  {
+    Console.WriteLine("Linux.Bluetooth Agent Example");
+
+    using var connection = new Connection(Address.System);
+    await connection.ConnectAsync();
+
+    //var capability = "DisplayOnly";
+    //var capability = "DisplayYesNo";
+    //var capability = "KeyboardOnly";
+    var capability = "NoInputNoOutput";
+    //var capability = "KeyboardDisplay";
+
+    using var agent = await BlueZManager.CreateAgentAsync(connection, capability);
+
+    Console.WriteLine($"Agent created with capability: {agent.Capability}");
+    Console.WriteLine($"Agent object path: {agent.ObjectPath}");
+
+    agent.SetDefaultPinCode("1234");
+    agent.SetDefaultPasskey(123456);
+
+    agent.PinCodeRequested += (sender, eventArgs) =>
+    {
+      Console.WriteLine($"PIN code requested for device: {eventArgs.Device}");
+      Console.Write("Enter your PIN code: ");
+      var pin = Console.ReadLine()!;
+      return Task.FromResult(pin);
+    };
+
+    agent.PasskeyRequested += (sender, eventArgs) =>
+    {
+      Console.WriteLine($"Passkey requested for device: {eventArgs.Device}");
+      Console.Write("Enter your passkey: ");
+      var passkey = uint.Parse(Console.ReadLine()!);
+      return Task.FromResult(passkey);
+    };
+
+    agent.ConfirmationRequested += (sender, eventArgs) =>
+    {
+      Console.WriteLine($"Confirmation requested for device: {eventArgs.Device}, passkey: {eventArgs.Passkey}");
+      return Task.CompletedTask;
+    };
+
+    agent.AuthorizationRequested += (sender, eventArgs) =>
+    {
+      Console.WriteLine($"Authorization requested for device: {eventArgs.Device}");
+      return Task.CompletedTask;
+    };
+
+    agent.ServiceAuthorizationRequested += (sender, eventArgs) =>
+    {
+      Console.WriteLine($"Service authorization requested for device: {eventArgs.Device}, service: {eventArgs.ServiceUuid}");
+      return Task.CompletedTask;
+    };
+
+    agent.PinCodeDisplayed += (sender, eventArgs) =>
+    {
+      Console.WriteLine($"Display PIN code for device {eventArgs.Device}: {eventArgs.PinCode}");
+      return Task.CompletedTask;
+    };
+
+    agent.PasskeyDisplayed += (sender, eventArgs) =>
+    {
+      Console.WriteLine($"Display passkey for device {eventArgs.Device}: {eventArgs.Passkey} (entered: {eventArgs.Entered})");
+      return Task.CompletedTask;
+    };
+
+    agent.OperationCancelled += (sender, eventArgs) =>
+    {
+      Console.WriteLine("Operation cancelled");
+      return Task.CompletedTask;
+    };
+
+    var agentManager = await BlueZManager.GetAgentManagerAsync(connection);
+    Console.WriteLine($"AgentManager object path: {agentManager.ObjectPath}");
+
+    await agentManager.RegisterAgentAsync(agent.ObjectPath, agent.Capability);
+    await agentManager.RequestDefaultAgentAsync(agent.ObjectPath);
+
+    var adapters = await BlueZManager.GetAdaptersAsync();
+    var adapter = adapters[0];
+    Console.WriteLine($"Selected adapter {adapter.Name} ({adapter.ObjectPath})");
+
+    if (!await adapter.GetPoweredAsync())
+    {
+      await adapter.SetPoweredAsync(true);
+    }
+
+    await adapter.SetPairableAsync(true);
+    await adapter.SetDiscoverableAsync(true);
+
+    Console.WriteLine("Now try to connect to this device and do some actions.");
+
+    while (true)
+    {
+      var devices = await adapter.GetDevicesAsync();
+
+      foreach (var device in devices)
+      {
+        var connected = await device.GetConnectedAsync();
+        Console.WriteLine($"Connected: {connected}; Device: {device.ObjectPath}");
+
+        var trusted = await device.GetTrustedAsync();
+        Console.WriteLine($"Trusted: {trusted}; Device: {device.ObjectPath}");
+
+        if (connected)
+        {
+          if (!trusted)
+          {
+            Console.WriteLine($"Pairing device {device.ObjectPath}");
+            await device.PairAsync();
+            Console.WriteLine($"Paired device {device.ObjectPath}");
+
+            Console.WriteLine($"Trusting device {device.ObjectPath}");
+            await device.SetTrustedAsync(true);
+            Console.WriteLine($"Trusted device {device.ObjectPath}");
+          }
+        }
+      }
+
+      await Task.Delay(1000);
+    }
+  }
+}

--- a/src/Linux.Bluetooth/Agent.cs
+++ b/src/Linux.Bluetooth/Agent.cs
@@ -1,0 +1,418 @@
+﻿using System;
+using System.Threading.Tasks;
+using Tmds.DBus;
+
+namespace Linux.Bluetooth
+{
+  // Manually defined interface according to BlueZ API specifications:
+  // https://github.com/bluez/bluez/blob/master/doc/org.bluez.Agent.rst
+  [DBusInterface("org.bluez.Agent1")]
+  public interface IAgent1 : IDBusObject
+  {
+    Task ReleaseAsync();
+    Task<string> RequestPinCodeAsync(ObjectPath device);
+    Task DisplayPinCodeAsync(ObjectPath device, string pincode);
+    Task<uint> RequestPasskeyAsync(ObjectPath device);
+    Task DisplayPasskeyAsync(ObjectPath device, uint passkey, ushort entered);
+    Task RequestConfirmationAsync(ObjectPath device, uint passkey);
+    Task RequestAuthorizationAsync(ObjectPath device);
+    Task AuthorizeServiceAsync(ObjectPath device, string uuid);
+    Task CancelAsync();
+  }
+
+  public delegate Task<string> AgentPinCodeEventHandlerAsync(Agent sender, AgentPinCodeEventArgs eventArgs);
+
+  public delegate Task<uint> AgentPasskeyEventHandlerAsync(Agent sender, AgentPasskeyEventArgs eventArgs);
+
+  public delegate Task AgentConfirmationEventHandlerAsync(Agent sender, AgentConfirmationEventArgs eventArgs);
+
+  public delegate Task AgentAuthorizationEventHandlerAsync(Agent sender, AgentAuthorizationEventArgs eventArgs);
+
+  public delegate Task AgentServiceAuthorizationEventHandlerAsync(Agent sender, AgentServiceAuthorizationEventArgs eventArgs);
+
+  public delegate Task AgentDisplayPinCodeEventHandlerAsync(Agent sender, AgentDisplayPinCodeEventArgs eventArgs);
+
+  public delegate Task AgentDisplayPasskeyEventHandlerAsync(Agent sender, AgentDisplayPasskeyEventArgs eventArgs);
+
+  public delegate Task AgentOperationCancelledEventHandlerAsync(Agent sender, EventArgs eventArgs);
+
+  /// <summary>
+  /// BlueZ D-Bus Agent.
+  /// </summary>
+  /// <remarks>
+  ///   Reference: https://github.com/bluez/bluez/blob/master/doc/org.bluez.Agent.rst
+  /// </remarks>
+  public class Agent : IAgent1, IDisposable
+  {
+    private const string DefaultCapability = "NoInputNoOutput";
+
+    private readonly string _capability;
+    private readonly ObjectPath _objectPath;
+    private readonly Connection _connection;
+
+    private string _defaultPinCode = "0000";
+    private uint _defaultPasskey = 000000;
+
+    private event AgentPinCodeEventHandlerAsync? _pinCodeRequested;
+    private event AgentPasskeyEventHandlerAsync? _passkeyRequested;
+    private event AgentConfirmationEventHandlerAsync? _confirmationRequested;
+    private event AgentAuthorizationEventHandlerAsync? _authorizationRequested;
+    private event AgentServiceAuthorizationEventHandlerAsync? _serviceAuthorizationRequested;
+    private event AgentDisplayPinCodeEventHandlerAsync? _pinCodeDisplayed;
+    private event AgentDisplayPasskeyEventHandlerAsync? _passkeyDisplayed;
+    private event AgentOperationCancelledEventHandlerAsync? _operationCancelled;
+
+    ~Agent()
+    {
+      Dispose();
+    }
+
+    private Agent(Connection connection, string capability = DefaultCapability, ObjectPath? objectPath = null)
+    {
+      _connection = connection;
+      _capability = capability;
+      _objectPath = objectPath ?? new ObjectPath($"/linux/bluetooth/agent/{Guid.NewGuid().ToString().Replace("-", string.Empty)}");
+    }
+
+    /// <summary>
+    /// Creates and registers a new BlueZ Agent on the D-Bus system.
+    /// </summary>
+    /// <param name="connection">
+    /// The D-Bus system connection instance for agent registration.
+    /// <para>This connection must be the same instance used for Agent and AgentManager.</para>
+    /// </param>
+    /// <param name="capability">The agent capability level. Default is "NoInputNoOutput". 
+    /// Possible values: "DisplayOnly", "DisplayYesNo", "KeyboardOnly", "KeyboardDisplay".</param>
+    /// <param name="objectPath">Optional custom D-Bus object path. If null, a unique path will be generated.</param>
+    /// <remarks>
+    /// <para>The agent is automatically registered on the D-Bus system and ready to handle pairing requests from BlueZ daemon.</para>
+    /// Always pass the same Connection instance to both Agent.CreateAsync() and AgentManager.CreateAsync().
+    /// </remarks>
+    /// <returns>A task that completes with a new Agent instance.</returns>
+    internal static async Task<Agent> CreateAsync(Connection connection, string capability = DefaultCapability, ObjectPath? objectPath = null)
+    {
+      var agent = new Agent(connection, capability, objectPath);
+      await agent.RegisterObjectAsync();
+      return agent;
+    }
+
+    public void Dispose()
+    {
+      UnregisterObject();
+      GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Gets the D-Bus object path of this agent.
+    /// </summary>
+    /// <remarks>
+    /// This path is used to identify the agent in BlueZ operations.
+    /// </remarks>
+    public ObjectPath ObjectPath => _objectPath;
+
+    /// <summary>
+    /// Gets the capability level of this agent.
+    /// </summary>
+    /// <remarks>
+    /// Possible values: "NoInputNoOutput", "DisplayOnly", "DisplayYesNo", "KeyboardOnly", "KeyboardDisplay".
+    /// </remarks>
+    public string Capability => _capability;
+
+    /// <summary>
+    /// Sets the default PIN code to be used for device pairing.
+    /// </summary>
+    /// <param name="pinCode">The PIN code (1-16 alphanumeric characters).</param>
+    /// <exception cref="ArgumentNullException">Thrown if pinCode is null.</exception>
+    /// <exception cref="ArgumentException">Thrown if pinCode length is invalid or contains non-alphanumeric characters.</exception>
+    public void SetDefaultPinCode(string pinCode)
+    {
+      if (pinCode is null)
+      {
+        throw new ArgumentNullException(nameof(pinCode));
+      }
+
+      if (pinCode.Length < 1 || pinCode.Length > 16)
+      {
+        throw new ArgumentException("PIN code must be between 1 and 16 characters.", nameof(pinCode));
+      }
+
+      foreach (var c in pinCode)
+      {
+        if (!char.IsLetterOrDigit(c))
+        {
+          throw new ArgumentException("PIN code must be alphanumeric.", nameof(pinCode));
+        }
+      }
+
+      _defaultPinCode = pinCode;
+    }
+
+    /// <summary>
+    /// Sets the default passkey to be used for Bluetooth 2.1 Secure Simple Pairing (SSP).
+    /// </summary>
+    /// <param name="passkey">The passkey (0-999999).</param>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown if passkey is greater than 999999.</exception>
+    public void SetDefaultPasskey(uint passkey)
+    {
+      if (passkey > 999999)
+      {
+        throw new ArgumentOutOfRangeException(nameof(passkey), "Passkey must be between 0 and 999999.");
+      }
+
+      _defaultPasskey = passkey;
+    }
+
+    private void UnregisterObject()
+    {
+      _connection.UnregisterObject(_objectPath);
+    }
+
+    private async Task RegisterObjectAsync()
+    {
+      await _connection.RegisterObjectAsync(this);
+    }
+
+    /// <summary>
+    /// Occurs when bluetoothd(8) requests a PIN code for pairing.
+    /// </summary>
+    public event AgentPinCodeEventHandlerAsync PinCodeRequested
+    {
+      add { _pinCodeRequested += value; }
+      remove { _pinCodeRequested -= value; }
+    }
+
+    /// <summary>
+    /// Occurs when bluetoothd(8) requests a passkey for Secure Simple Pairing (SSP).
+    /// </summary>
+    public event AgentPasskeyEventHandlerAsync PasskeyRequested
+    {
+      add { _passkeyRequested += value; }
+      remove { _passkeyRequested -= value; }
+    }
+
+    /// <summary>
+    /// Occurs when bluetoothd(8) requests confirmation of a passkey.
+    /// </summary>
+    public event AgentConfirmationEventHandlerAsync ConfirmationRequested
+    {
+      add { _confirmationRequested += value; }
+      remove { _confirmationRequested -= value; }
+    }
+
+    /// <summary>
+    /// Occurs when bluetoothd(8) requests authorization for an incoming pairing.
+    /// </summary>
+    public event AgentAuthorizationEventHandlerAsync AuthorizationRequested
+    {
+      add { _authorizationRequested += value; }
+      remove { _authorizationRequested -= value; }
+    }
+
+    /// <summary>
+    /// Occurs when bluetoothd(8) requests authorization for service access.
+    /// </summary>
+    public event AgentServiceAuthorizationEventHandlerAsync ServiceAuthorizationRequested
+    {
+      add { _serviceAuthorizationRequested += value; }
+      remove { _serviceAuthorizationRequested -= value; }
+    }
+
+    /// <summary>
+    /// Occurs when bluetoothd(8) needs to display a PIN code for pairing.
+    /// </summary>
+    public event AgentDisplayPinCodeEventHandlerAsync PinCodeDisplayed
+    {
+      add { _pinCodeDisplayed += value; }
+      remove { _pinCodeDisplayed -= value; }
+    }
+
+    /// <summary>
+    /// Occurs when bluetoothd(8) needs to display a passkey for SSP pairing.
+    /// </summary>
+    public event AgentDisplayPasskeyEventHandlerAsync PasskeyDisplayed
+    {
+      add { _passkeyDisplayed += value; }
+      remove { _passkeyDisplayed -= value; }
+    }
+
+    /// <summary>
+    /// Occurs when a pairing request is cancelled by bluetoothd(8).
+    /// </summary>
+    public event AgentOperationCancelledEventHandlerAsync OperationCancelled
+    {
+      add { _operationCancelled += value; }
+      remove { _operationCancelled -= value; }
+    }
+
+    /// <summary>
+    /// This method gets called when bluetoothd(8) unregisters the agent.
+    /// </summary>
+    /// <remarks>
+    /// An agent can use it to do cleanup tasks. There is no need to unregister the agent,
+    /// because when this method gets called it has already been unregistered.
+    /// </remarks>
+    /// <returns>A task representing the asynchronous cleanup operation.</returns>
+    public Task ReleaseAsync()
+    {
+      return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// This method gets called when bluetoothd(8) needs to get the passkey for an authentication.
+    /// The return value should be a string of 1-16 characters length. The string can be alphanumeric.
+    /// </summary>
+    /// <param name="device">The object path of the device requesting authentication.</param>
+    /// <remarks>
+    /// Possible errors:
+    /// <list type="bullet">
+    ///   <item>org.bluez.Error.Rejected</item>
+    ///   <item>org.bluez.Error.Canceled</item>
+    /// </list>
+    /// </remarks>
+    /// <returns>A task that completes with a <c>string</c> representing the PIN code for authentication.</returns>
+    public Task<string> RequestPinCodeAsync(ObjectPath device)
+    {
+      if (_pinCodeRequested is not null)
+      {
+        return _pinCodeRequested(this, new AgentPinCodeEventArgs(device));
+      }
+
+      return Task.FromResult(_defaultPinCode);
+    }
+
+    /// <summary>
+    /// This method gets called when bluetoothd(8) needs to display a pincode for an authentication.
+    /// An empty reply should be returned.
+    /// <para>When the pincode needs no longer to be displayed, the Cancel method of the agent will be called.</para>
+    /// </summary>
+    /// <param name="device">The object path of the device requesting authentication.</param>
+    /// <param name="pincode">The PIN code to display (typically 6 digits, zero-padded).</param>
+    /// <remarks>
+    /// This is used during the pairing process of keyboards that don't support Bluetooth 2.1 Secure Simple Pairing,
+    /// in contrast to DisplayPasskey which is used for those that do.
+    /// <para>This method will only ever be called once since older keyboards do not support typing notification.</para>
+    /// <para>Note that the PIN will always be a 6-digit number, zero-padded to 6 digits.
+    /// This is for harmony with the later specification.</para>
+    /// Possible errors:
+    /// <list type="bullet">
+    ///   <item>org.bluez.Error.Rejected</item>
+    ///   <item>org.bluez.Error.Canceled</item>
+    /// </list>
+    /// </remarks>
+    /// <returns>A task representing the asynchronous PIN code display operation to the subscriber.</returns>
+    public Task DisplayPinCodeAsync(ObjectPath device, string pincode)
+    {
+      return _pinCodeDisplayed?.Invoke(this, new AgentDisplayPinCodeEventArgs(device, pincode)) ?? Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// This method gets called when bluetoothd(8) needs to get the passkey for an authentication.
+    /// The return value should be a numeric value between 0-999999.
+    /// </summary>
+    /// <param name="device">The object path of the device requesting authentication.</param>
+    /// <remarks>
+    /// Possible errors:
+    /// <list type="bullet">
+    ///   <item>org.bluez.Error.Rejected</item>
+    ///   <item>org.bluez.Error.Canceled</item>
+    /// </list>
+    /// </remarks>
+    /// <returns>A task that completes with a <c>uint</c> representing the passkey for authentication.</returns>
+    public Task<uint> RequestPasskeyAsync(ObjectPath device)
+    {
+      if (_passkeyRequested is not null)
+      {
+        return _passkeyRequested(this, new AgentPasskeyEventArgs(device));
+      }
+
+      return Task.FromResult(_defaultPasskey);
+    }
+
+    /// <summary>
+    /// This method gets called when bluetoothd(8) needs to display a passkey for an authentication.
+    /// <para>The entered parameter indicates the number of already typed keys on the remote side.</para>
+    /// An empty reply should be returned.When the passkey needs no longer to be displayed, the Cancel method of the agent will be called.
+    /// </summary>
+    /// <param name="device">The object path of the device requesting authentication.</param>
+    /// <param name="passkey">The passkey to display (0-999999, typically 6 digits).</param>
+    /// <param name="entered">The number of digits already entered by the user on the remote device.</param>
+    /// <remarks>
+    /// During the pairing process this method might be called multiple times to update the entered value.
+    /// <para>Note that the passkey will always be a 6 - digit number,
+    /// so the display should be zero-padded at the start if the value contains less than 6 digits.</para>
+    /// </remarks>
+    /// <returns>A task representing the asynchronous passkey display operation to the subscriber.</returns>
+    public Task DisplayPasskeyAsync(ObjectPath device, uint passkey, ushort entered)
+    {
+      return _passkeyDisplayed?.Invoke(this, new AgentDisplayPasskeyEventArgs(device, passkey, entered)) ?? Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// This method gets called when bluetoothd(8) needs to confirm a passkey for an authentication.
+    /// <para>To confirm the value it should return an empty reply or an error in case the passkey is invalid.</para>
+    /// </summary>
+    /// <param name="device">The object path of the device requesting authentication.</param>
+    /// <param name="passkey">The passkey to confirm (0-999999, typically 6 digits).</param>
+    /// <remarks>
+    /// <para>Note that the passkey will always be a 6-digit number,
+    /// so the display should be zero-padded at the start if the value contains less than 6 digits.</para>
+    /// Possible errors:
+    /// <list type="bullet">
+    ///   <item>org.bluez.Error.Rejected</item>
+    ///   <item>org.bluez.Error.Canceled</item>
+    /// </list>
+    /// </remarks>
+    /// <returns>A task representing the asynchronous passkey confirmation request to the subscriber.</returns>
+    public Task RequestConfirmationAsync(ObjectPath device, uint passkey)
+    {
+      return _confirmationRequested?.Invoke(this, new AgentConfirmationEventArgs(device, passkey)) ?? Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// This method gets called to request the user to authorize an incoming pairing attempt
+    /// which would in other circumstances trigger the just-works model,
+    /// or when the user plugged in a device that implements cable pairing.
+    /// In the latter case, the device would not be connected to the adapter via Bluetooth yet.
+    /// </summary>
+    /// <param name="device">The object path of the device requesting authorization.</param>
+    /// <remarks>
+    /// Possible errors:
+    /// <list type="bullet">
+    ///   <item>org.bluez.Error.Rejected</item>
+    ///   <item>org.bluez.Error.Canceled</item>
+    /// </list>
+    /// </remarks>
+    /// <returns>A task representing the asynchronous authorization request to the subscriber.</returns>
+    public Task RequestAuthorizationAsync(ObjectPath device)
+    {
+      return _authorizationRequested?.Invoke(this, new AgentAuthorizationEventArgs(device)) ?? Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// This method gets called when the service daemon needs to authorize a connection/service request.
+    /// </summary>
+    /// <param name="device">The object path of the device requesting service access.</param>
+    /// <param name="uuid">The UUID of the service being authorized.</param>
+    /// <remarks>
+    /// Possible errors:
+    /// <list type="bullet">
+    ///   <item>org.bluez.Error.Rejected</item>
+    ///   <item>org.bluez.Error.Canceled</item>
+    /// </list>
+    /// </remarks>
+    /// <returns>A task representing the asynchronous service authorization request to the subscriber.</returns>
+    public Task AuthorizeServiceAsync(ObjectPath device, string uuid)
+    {
+      return _serviceAuthorizationRequested?.Invoke(this, new AgentServiceAuthorizationEventArgs(device, uuid)) ?? Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// This method gets called to indicate that the agent request failed before a reply was returned.
+    /// </summary>
+    /// <returns>A task representing the asynchronous cancellation notification to the subscriber.</returns>
+    public Task CancelAsync()
+    {
+      return _operationCancelled?.Invoke(this, EventArgs.Empty) ?? Task.CompletedTask;
+    }
+  }
+}

--- a/src/Linux.Bluetooth/AgentManager.cs
+++ b/src/Linux.Bluetooth/AgentManager.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Threading.Tasks;
+using Tmds.DBus;
+
+namespace Linux.Bluetooth;
+
+/// <summary>
+/// BlueZ D-Bus Agent Manager.
+/// </summary>
+/// <remarks>
+///   Reference: https://github.com/bluez/bluez/blob/master/doc/org.bluez.AgentManager.rst
+/// </remarks>
+public class AgentManager : IAgentManager1, IDisposable
+{
+  private readonly IAgentManager1 _proxy;
+
+  ~AgentManager()
+  {
+    Dispose();
+  }
+
+  private AgentManager(IAgentManager1 proxy)
+  {
+    _proxy = proxy;
+  }
+
+  /// <summary>
+  /// Creates a new AgentManager instance connected to the BlueZ service.
+  /// </summary>
+  /// <param name="connection">
+  /// The D-Bus system connection instance to use for agent management operations.
+  /// <para>This connection must be the same instance used for Agent and AgentManager.</para>
+  /// </param>
+  /// <remarks>
+  /// <para>The AgentManager is used to register, unregister, and set default pairing agents for the system.</para>
+  /// Always pass the same Connection instance to both Agent.CreateAsync() and AgentManager.CreateAsync().
+  /// </remarks>
+  /// <returns>A task that completes with a new AgentManager instance.</returns>
+  internal static Task<AgentManager> CreateAsync(Connection connection)
+  {
+    var proxy = connection.CreateProxy<IAgentManager1>(BluezConstants.DbusService, "/org/bluez");
+    return Task.FromResult(new AgentManager(proxy));
+  }
+
+  /// <summary>
+  /// Releases resources used by the AgentManager.
+  /// </summary>
+  public void Dispose()
+  {
+    GC.SuppressFinalize(this);
+  }
+
+  /// <summary>
+  /// Gets the D-Bus object path of the BlueZ Agent Manager.
+  /// </summary>
+  public ObjectPath ObjectPath => _proxy?.ObjectPath ?? new ObjectPath("/org/bluez");
+
+  /// <summary>
+  /// Registers pairing agent.
+  /// <para>The object path defines the path of the agent that will be called
+  /// when user input is needed and must implement org.bluez.Agent(5) interface.</para>
+  /// </summary>
+  /// <param name="Agent">The object path of the agent implementation.</param>
+  /// <param name="Capability">
+  /// Possible capability values:
+  /// <list type="bullet">
+  ///   <item>"" - Fallback to "KeyboardDisplay"</item>
+  ///   <item>"DisplayOnly"</item>
+  ///   <item>"DisplayYesNo"</item>
+  ///   <item>"KeyboardOnly"</item>
+  ///   <item>"NoInputNoOutput"</item>
+  ///   <item>"KeyboardDisplay"</item>
+  /// </list>
+  /// </param>
+  /// <remarks>
+  /// Every application can register its own agent and for all actions triggered by that application its agent is used.
+  /// <para>It is not required by an application to register an agent.
+  /// If an application does chooses to not register an agent, the default agent is used. This is on most cases a good idea.
+  /// Only application like a pairing wizard should register their own agent.</para>
+  /// An application can only register one agent.Multiple agents per application is not supported.
+  /// Possible errors:
+  /// <list type="bullet">
+  ///   <item>org.bluez.Error.InvalidArguments</item>
+  ///   <item>org.bluez.Error.AlreadyExists</item>
+  /// </list>
+  /// </remarks>
+  /// <returns>A task representing the asynchronous agent registration operation.</returns>
+  public Task RegisterAgentAsync(ObjectPath Agent, string Capability)
+  {
+    return _proxy!.RegisterAgentAsync(Agent, Capability);
+  }
+
+  /// <summary>
+  /// Unregisters an agent that has been previously registered using RegisterAgent.
+  /// The object path parameter must match the same value that has been used on registration.
+  /// </summary>
+  /// <param name="Agent">The object path of the agent implementation to unregister.</param>
+  /// <remarks>
+  /// Possible errors:
+  /// <list type="bullet">
+  ///   <item>org.bluez.Error.DoesNotExist</item>
+  /// </list>
+  /// </remarks>
+  /// <returns>A task representing the asynchronous agent unregistration operation.</returns>
+  public Task UnregisterAgentAsync(ObjectPath Agent)
+  {
+    return _proxy!.UnregisterAgentAsync(Agent);
+  }
+
+  /// <summary>
+  /// Requests to make the application agent the default agent. The application is required to register an agent.
+  /// <para>Special permission might be required to become the default agent.</para>
+  /// </summary>
+  /// <param name="Agent">The object path of the agent to set as default.</param>
+  /// <remarks>
+  /// Possible errors:
+  /// <list type="bullet">
+  ///   <item>org.bluez.Error.DoesNotExist</item>
+  /// </list>
+  /// </remarks>
+  /// <returns>A task representing the asynchronous operation to set the default agent.</returns>
+  public Task RequestDefaultAgentAsync(ObjectPath Agent)
+  {
+    return _proxy!.RequestDefaultAgentAsync(Agent);
+  }
+}

--- a/src/Linux.Bluetooth/BlueZManager.cs
+++ b/src/Linux.Bluetooth/BlueZManager.cs
@@ -30,6 +30,16 @@ namespace Linux.Bluetooth
       return await Adapter.CreateAsync(adapter);
     }
 
+    public static Task<AgentManager> GetAgentManagerAsync(Connection connection)
+    {
+      return AgentManager.CreateAsync(connection);
+    }
+
+    public static Task<Agent> CreateAgentAsync(Connection connection, string capability = "NoInputNoOutput", ObjectPath? objectPath = null)
+    {
+      return Agent.CreateAsync(connection, capability, objectPath);
+    }
+
     public static async Task<IReadOnlyList<Adapter>> GetAdaptersAsync()
     {
       var adapters = await GetProxiesAsync<IAdapter1>(BluezConstants.AdapterInterface, rootObject: null);

--- a/src/Linux.Bluetooth/Constants/BluezConstants.cs
+++ b/src/Linux.Bluetooth/Constants/BluezConstants.cs
@@ -5,6 +5,8 @@
     public const string DbusService = "org.bluez";
 
     public const string AdapterInterface = "org.bluez.Adapter1";
+    public const string AgentInterface = "org.bluez.Agent1";
+    public const string AgentManagerInterface = "org.bluez.AgentManager1";
     public const string BatteryInterface = "org.bluez.Battery1";
     public const string DeviceInterface = "org.bluez.Device1";
     public const string GattServiceInterface = "org.bluez.GattService1";

--- a/src/Linux.Bluetooth/EventArgs.cs
+++ b/src/Linux.Bluetooth/EventArgs.cs
@@ -1,44 +1,26 @@
 ﻿using System;
-using System.Collections.Generic;
 using Tmds.DBus;
 
 namespace Linux.Bluetooth
 {
-  public class BlueZEventArgs : EventArgs
+  public class BlueZEventArgs(bool isStateChange = true) : EventArgs
   {
-    public BlueZEventArgs(bool isStateChange = true)
-    {
-      IsStateChange = isStateChange;
-    }
-
-    public bool IsStateChange { get; }
+    public bool IsStateChange { get; } = isStateChange;
   }
 
-  public class DeviceFoundEventArgs : BlueZEventArgs
+  public class DeviceFoundEventArgs(Device device, bool isStateChange = true) : BlueZEventArgs(isStateChange)
   {
-    public DeviceFoundEventArgs(Device device, bool isStateChange = true)
-      : base(isStateChange)
-    {
-      Device = device;
-    }
-
-    public Device Device { get; }
+    public Device Device { get; } = device;
   }
 
-  public class GattCharacteristicValueEventArgs : EventArgs
+  public class GattCharacteristicValueEventArgs(byte[] value) : EventArgs
   {
-    public GattCharacteristicValueEventArgs(byte[] value)
-    {
-      Value = value;
-    }
-
-    public byte[] Value { get; }
+    public byte[] Value { get; } = value;
   }
 
   public class GattCharacteristicServerValueEventArgs(object devicePath, byte[] value) : EventArgs
   {
     public object DevicePath { get; } = devicePath;
-
     public byte[] Value { get; } = value;
   }
 
@@ -47,6 +29,46 @@ namespace Linux.Bluetooth
     public object DevicePath { get; } = devicePath;
 
     public byte[] Value { get; } = value;
+  }
+
+  public class AgentPinCodeEventArgs(ObjectPath device) : EventArgs
+  {
+    public ObjectPath Device { get; } = device;
+  }
+
+  public class AgentPasskeyEventArgs(ObjectPath device) : EventArgs
+  {
+    public ObjectPath Device { get; } = device;
+  }
+
+  public class AgentConfirmationEventArgs(ObjectPath device, uint passkey) : EventArgs
+  {
+    public ObjectPath Device { get; } = device;
+    public uint Passkey { get; } = passkey;
+  }
+
+  public class AgentAuthorizationEventArgs(ObjectPath device) : EventArgs
+  {
+    public ObjectPath Device { get; } = device;
+  }
+
+  public class AgentServiceAuthorizationEventArgs(ObjectPath device, string uuid) : EventArgs
+  {
+    public ObjectPath Device { get; } = device;
+    public string ServiceUuid { get; } = uuid;
+  }
+
+  public class AgentDisplayPinCodeEventArgs(ObjectPath device, string pincode) : EventArgs
+  {
+    public ObjectPath Device { get; } = device;
+    public string PinCode { get; } = pincode;
+  }
+
+  public class AgentDisplayPasskeyEventArgs(ObjectPath device, uint passkey, ushort entered) : EventArgs
+  {
+    public ObjectPath Device { get; } = device;
+    public uint Passkey { get; } = passkey;
+    public ushort Entered { get; } = entered;
   }
 
 }


### PR DESCRIPTION
## Details

This PR adds an implementation of the BlueZ pairing Agent and AgentManager.

The Agent implements the `org.bluez.Agent1` interface and allows applications
to handle incoming Bluetooth pairing requests (PIN code, passkey, confirmation,
authorization, and service authorization).

The AgentManager provides a wrapper for the `org.bluez.AgentManager1` interface
and is used to register, unregister, and optionally set the agent as the
default system agent.

An example project demonstrating how to work with the BlueZ Agent was also added.

All capability modes were tested:

- DisplayOnly
- DisplayYesNo
- KeyboardOnly
- NoInputNoOutput
- KeyboardDisplay

Testing environment:

- Raspberry Pi 3
- Raspberry Pi OS 64-bit (Debian 13 "Trixie")

During testing the following Bluetooth daemon configuration with custom settings
was used (`/etc/bluetooth/main.conf`):

```
Class = 0x200414
AlwaysPairable = true
FastConnectable = true
JustWorksRepairing = always
AutoEnable = false
```

## Linked To Issue/Feature

* #55 - _issue/discussion_
* #34 - _issue/discussion_
