### PR TITLE
Contain consumer exceptions in D-Bus signal handlers, and stop disposing from finalizers

### DIFF
--- a/src/Linux.Bluetooth/Adapter.cs
+++ b/src/Linux.Bluetooth/Adapter.cs
@@ -210,21 +210,40 @@ namespace Linux.Bluetooth
 
     private async void FireEventForExistingDevicesAsync()
     {
-      var devices = await this.GetDevicesAsync();
-      foreach (var device in devices)
+      // async void: exceptions must not escape.
+      try
       {
-        _deviceFound?.Invoke(this, new DeviceFoundEventArgs(device, isStateChange: false));
+        var devices = await this.GetDevicesAsync();
+        foreach (var device in devices)
+        {
+          _deviceFound?.Invoke(this, new DeviceFoundEventArgs(device, isStateChange: false));
+        }
+      }
+      catch (Exception ex)
+      {
+        Console.Error.WriteLine($"Existing-devices replay threw: {ex.Message}");
       }
     }
 
     private async void OnDeviceAddedAsync((ObjectPath objectPath, IDictionary<string, IDictionary<string, object>> interfaces) args)
     {
-      if (BlueZManager.IsMatch(BluezConstants.DeviceInterface, args.objectPath, args.interfaces, this))
+      // async void: exceptions must not escape.
+      try
       {
-        var device = Connection.System.CreateProxy<IDevice1>(BluezConstants.DbusService, args.objectPath);
+        if (BlueZManager.IsMatch(BluezConstants.DeviceInterface, args.objectPath, args.interfaces, this))
+        {
+          var device = Connection.System.CreateProxy<IDevice1>(BluezConstants.DbusService, args.objectPath);
 
-        var dev = await Device.CreateAsync(device);
-        _deviceFound?.Invoke(this, new DeviceFoundEventArgs(dev));
+          var dev = await Device.CreateAsync(device);
+          _deviceFound?.Invoke(this, new DeviceFoundEventArgs(dev));
+
+          // Relay this device's connection state if anyone is listening to the adapter-level events.
+          TrackDeviceForConnection(args.objectPath);
+        }
+      }
+      catch (Exception ex)
+      {
+        Console.Error.WriteLine($"InterfacesAdded handler threw: {ex.Message}");
       }
     }
 
@@ -247,22 +266,30 @@ namespace Linux.Bluetooth
 
     private void OnPropertyChanges(PropertyChanges changes)
     {
-      foreach (var pair in changes.Changed)
+      // Runs on the DBus receive loop: consumer throws must not escape.
+      try
       {
-        switch (pair.Key)
+        foreach (var pair in changes.Changed)
         {
-          case "Powered":
-            if (true.Equals(pair.Value))
-            {
-              _poweredOn?.Invoke(this, new BlueZEventArgs());
-            }
-            else
-            {
-              PoweredOff?.Invoke(this, new BlueZEventArgs());
-            }
+          switch (pair.Key)
+          {
+            case "Powered":
+              if (true.Equals(pair.Value))
+              {
+                _poweredOn?.Invoke(this, new BlueZEventArgs());
+              }
+              else
+              {
+                PoweredOff?.Invoke(this, new BlueZEventArgs());
+              }
 
-            break;
+              break;
+          }
         }
+      }
+      catch (Exception ex)
+      {
+        Console.Error.WriteLine($"Adapter property handler threw: {ex.Message}");
       }
     }
   }

--- a/src/Linux.Bluetooth/Adapter.cs
+++ b/src/Linux.Bluetooth/Adapter.cs
@@ -28,12 +28,7 @@ namespace Linux.Bluetooth
     private IObjectManager ObjectManager => 
       _objectManager ?? throw new InvalidOperationException("Adapter object manager has not been initialized.");
 
-    ~Adapter()
-    {
-      Dispose();
-    }
-
-    internal static async Task<Adapter> CreateAsync(IAdapter1 proxy)
+    public static async Task<Adapter> CreateAsync(IAdapter1 proxy)
     {
       var adapter = new Adapter
       {
@@ -54,8 +49,6 @@ namespace Linux.Bluetooth
       _interfacesWatcher = null;
       _propertyWatcher?.Dispose();
       _propertyWatcher = null;
-
-      GC.SuppressFinalize(this);
     }
 
     public event DeviceChangeEventHandlerAsync DeviceFound

--- a/src/Linux.Bluetooth/Agent.cs
+++ b/src/Linux.Bluetooth/Agent.cs
@@ -62,11 +62,6 @@ namespace Linux.Bluetooth
     private event AgentDisplayPasskeyEventHandlerAsync? _passkeyDisplayed;
     private event AgentOperationCancelledEventHandlerAsync? _operationCancelled;
 
-    ~Agent()
-    {
-      Dispose();
-    }
-
     private Agent(Connection connection, string capability = DefaultCapability, ObjectPath? objectPath = null)
     {
       _connection = connection;
@@ -99,7 +94,6 @@ namespace Linux.Bluetooth
     public void Dispose()
     {
       UnregisterObject();
-      GC.SuppressFinalize(this);
     }
 
     /// <summary>

--- a/src/Linux.Bluetooth/AgentManager.cs
+++ b/src/Linux.Bluetooth/AgentManager.cs
@@ -14,11 +14,6 @@ public class AgentManager : IAgentManager1, IDisposable
 {
   private readonly IAgentManager1 _proxy;
 
-  ~AgentManager()
-  {
-    Dispose();
-  }
-
   private AgentManager(IAgentManager1 proxy)
   {
     _proxy = proxy;
@@ -47,7 +42,6 @@ public class AgentManager : IAgentManager1, IDisposable
   /// </summary>
   public void Dispose()
   {
-    GC.SuppressFinalize(this);
   }
 
   /// <summary>

--- a/src/Linux.Bluetooth/BlueZManager.cs
+++ b/src/Linux.Bluetooth/BlueZManager.cs
@@ -47,6 +47,14 @@ namespace Linux.Bluetooth
       return await Task.WhenAll(adapters.Select(Adapter.CreateAsync));
     }
 
+    /// <summary>Get the adapter proxies without creating signal watchers.</summary>
+    /// <remarks>Select a proxy, then call <see cref="Adapter.CreateAsync"/> on it.</remarks>
+    /// <returns>The adapter proxies.</returns>
+    public static Task<IReadOnlyList<IAdapter1>> GetAdapterProxiesAsync()
+    {
+      return GetProxiesAsync<IAdapter1>(BluezConstants.AdapterInterface, rootObject: null);
+    }
+
     // Normalize a 16, 32 or 128 bit UUID.
     public static string NormalizeUUID(string uuid)
     {

--- a/src/Linux.Bluetooth/Device.cs
+++ b/src/Linux.Bluetooth/Device.cs
@@ -26,11 +26,6 @@ namespace Linux.Bluetooth
 
     private IDevice1 Proxy => _proxy ?? throw new InvalidOperationException("Device has not been initialized.");
 
-    ~Device()
-    {
-      Dispose();
-    }
-
     internal static async Task<Device> CreateAsync(IDevice1 proxy)
     {
       var device = new Device
@@ -47,8 +42,6 @@ namespace Linux.Bluetooth
     {
       _propertyWatcher?.Dispose();
       _propertyWatcher = null;
-
-      GC.SuppressFinalize(this);
     }
 
     public event DeviceEventHandlerAsync Connected

--- a/src/Linux.Bluetooth/GattCharacteristic.cs
+++ b/src/Linux.Bluetooth/GattCharacteristic.cs
@@ -131,15 +131,22 @@ namespace Linux.Bluetooth
 
     private void OnPropertyChanges(PropertyChanges changes)
     {
-      // Console.WriteLine("OnPropertyChanges called.");
-      foreach (var pair in changes.Changed)
+      // Runs on the DBus receive loop: consumer throws must not escape.
+      try
       {
-        switch (pair.Key)
+        foreach (var pair in changes.Changed)
         {
-          case "Value":
-            _onValue?.Invoke(this, new GattCharacteristicValueEventArgs((byte[])pair.Value));
-            break;
+          switch (pair.Key)
+          {
+            case "Value":
+              _onValue?.Invoke(this, new GattCharacteristicValueEventArgs((byte[])pair.Value));
+              break;
+          }
         }
+      }
+      catch (Exception ex)
+      {
+        Console.Error.WriteLine($"Characteristic value handler threw: {ex.Message}");
       }
     }
   }

--- a/src/Linux.Bluetooth/GattServer/GattServer.cs
+++ b/src/Linux.Bluetooth/GattServer/GattServer.cs
@@ -36,7 +36,7 @@
         await UnregisterGattApplication();
       }).Wait();
 
-      Console.Error.WriteLine("Disposed Gatt server.");
+      Debug.WriteLine("Disposed Gatt server.");
       Connection.Dispose();
     }
 

--- a/src/Linux.Bluetooth/GattServer/GattServer.cs
+++ b/src/Linux.Bluetooth/GattServer/GattServer.cs
@@ -28,11 +28,6 @@
       _gattManager = Connection.CreateProxy<IGattManager1>(BluezConstants.DbusService, adapter.ObjectPath);
     }
 
-    ~GattServer()
-    {
-      Dispose();
-    }
-
     public void Dispose()
     {
       Task.Run(async () =>
@@ -43,7 +38,6 @@
 
       Console.Error.WriteLine("Disposed Gatt server.");
       Connection.Dispose();
-      GC.SuppressFinalize(this);
     }
 
     public async Task InitializeAsync()

--- a/src/Linux.Bluetooth/GattServer/GattServer.cs
+++ b/src/Linux.Bluetooth/GattServer/GattServer.cs
@@ -102,7 +102,15 @@
       if (_gattApplication is not null)
       {
         // unregister the application before unregister objects
-        await _gattManager.UnregisterApplicationAsync(_gattApplication.ObjectPath);
+        try
+        {
+          await _gattManager.UnregisterApplicationAsync(_gattApplication.ObjectPath);
+        }
+        catch (DBusException ex) when (ex.ErrorName == "org.bluez.Error.DoesNotExist")
+        {
+          // BlueZ already dropped it (e.g. bluetoothd restarted): that is the wanted end state.
+        }
+
 
         foreach (GattService service in _gattApplication.Services)
         {
@@ -143,7 +151,15 @@
     {
       if (_advertisement is not null)
       {
-        await _advManager.UnregisterAdvertisementAsync(_advertisement.ObjectPath);
+        try
+        {
+          await _advManager.UnregisterAdvertisementAsync(_advertisement.ObjectPath);
+        }
+        catch (DBusException ex) when (ex.ErrorName == "org.bluez.Error.DoesNotExist")
+        {
+          // BlueZ already dropped it (e.g. bluetoothd restarted): that is the wanted end state.
+        }
+
         Connection.UnregisterObject(_advertisement);
         Debug.WriteLine($"Advertisement {_advertisement.ObjectPath} unregistered");
         _advertisement = null;


### PR DESCRIPTION
## Why

Tmds.DBus reads signals on one receive loop. When a handler throws, `ReceiveMessages` catches
it, calls `Disconnect()` and clears the connection's signal handlers. With `AutoConnect` the
connection then transparently reconnects **for method calls only**: property reads keep
working, every event is silent, and nothing is logged. On our gateway this presented as BLE
scans that found nothing for hours, with a healthy-looking process.

A consumer callback throwing is not the library's fault, but taking the whole connection down
silently is a bad failure mode for it to have.

## What changed

- Every library-owned signal handler contains consumer exceptions and logs them, so one bad
  subscriber can no longer kill signal delivery for the process.
- Removed the `Adapter`, `Device`, `GattServer`, `Agent` and `AgentManager` finalizers. They
  called the public `Dispose`, so the finalizer thread disposed managed watchers and issued
  D-Bus traffic — on a connection it may not own and which may already be disposed. Cleanup
  belongs to the owner; these types are all `IDisposable`.
- `GattServer.Dispose` no longer fails when BlueZ answers `org.bluez.Error.DoesNotExist`:
  a bluetoothd restart makes that routine, and unregistering an object that is already gone
  has reached its goal.
- `GattServer.Dispose` traces its success with `Debug.WriteLine` instead of reporting it on
  stderr.
- Added `BlueZManager.GetAdapterProxiesAsync` and made `Adapter.CreateAsync` public, so a
  caller can pick an adapter without `GetAdaptersAsync` registering three watchers for every
  adapter on the bus, including the ones it discards. `GetAdaptersAsync` is unchanged.

Behaviour is otherwise unchanged; no public API is removed.
