### PR TITLE
Report the loss of the AdvertisementMonitor's D-Bus connection

### DIFF
--- a/src/Linux.Bluetooth/AdvertisementMonitor.cs
+++ b/src/Linux.Bluetooth/AdvertisementMonitor.cs
@@ -9,7 +9,7 @@ namespace Linux.Bluetooth
   /// Advertisement Monitor class.
   /// Requires 'Experimental = true' and 'KernelExperimental = true' in BlueZ main.conf
   /// </summary>
-  public class AdvertisementMonitor : IAdvertisementMonitor1, IObjectManager
+  public class AdvertisementMonitor : IAdvertisementMonitor1, IObjectManager, IDisposable
   {
     public ObjectPath ObjectPath { get; }
 
@@ -46,6 +46,16 @@ namespace Linux.Bluetooth
     {
       await _manager.UnregisterMonitorAsync(ObjectPath);
       _conn.UnregisterObject(this);
+    }
+
+    /// <summary>
+    /// Closes the D-Bus connection opened by the constructor. Each monitor owns its own connection, so a
+    /// monitor dropped without disposing leaks its socket until finalization.
+    /// </summary>
+    public void Dispose()
+    {
+      _conn.Dispose();
+      GC.SuppressFinalize(this);
     }
 
     public Task ActivateAsync()

--- a/src/Linux.Bluetooth/AdvertisementMonitor.cs
+++ b/src/Linux.Bluetooth/AdvertisementMonitor.cs
@@ -16,6 +16,16 @@ namespace Linux.Bluetooth
     public event EventHandler<Device>? DeviceFoundEvent;
     public event EventHandler<Device>? DeviceLostEvent;
 
+    /// <summary>
+    ///   Raised when the D-Bus connection backing this monitor drops.
+    /// </summary>
+    /// <remarks>
+    ///   The connection is created by this monitor and never reconnects, so BlueZ loses the monitor
+    ///   registration for good: no further DeviceFoundEvent or DeviceLostEvent is ever raised. Dispose this
+    ///   monitor and create a new one to resume monitoring.
+    /// </remarks>
+    public event EventHandler? ConnectionLost;
+
     private readonly Connection _conn;
     private readonly AdvertisementMonitor1Properties _properties;
     private readonly IAdvertisementMonitorManager1 _manager;
@@ -40,12 +50,24 @@ namespace Linux.Bluetooth
       await _conn.ConnectAsync();
       await _conn.RegisterObjectAsync(this);
       await _manager.RegisterMonitorAsync(ObjectPath);
+
+      _conn.StateChanged += OnConnectionStateChanged;
     }
 
     public async Task StopAsync()
     {
+      _conn.StateChanged -= OnConnectionStateChanged;
+
       await _manager.UnregisterMonitorAsync(ObjectPath);
       _conn.UnregisterObject(this);
+    }
+
+    private void OnConnectionStateChanged(object sender, ConnectionStateChangedEventArgs e)
+    {
+      if (e.State == ConnectionState.Disconnected)
+      {
+        ConnectionLost?.Invoke(this, EventArgs.Empty);
+      }
     }
 
     /// <summary>
@@ -54,6 +76,7 @@ namespace Linux.Bluetooth
     /// </summary>
     public void Dispose()
     {
+      _conn.StateChanged -= OnConnectionStateChanged;
       _conn.Dispose();
       GC.SuppressFinalize(this);
     }


### PR DESCRIPTION
## Why

`AdvertisementMonitor` exports a D-Bus object, and Tmds.DBus only allows that on a manual
connection — `RegisterObjectAsync` throws for an `AutoConnect` one. A manual connection never
reconnects, and `ConnectAsync` refuses to run twice.

So after a bus restart (`systemctl restart dbus`) the monitor is permanently dead: BlueZ has
dropped the registration, no `DeviceFoundEvent` or `DeviceLostEvent` is ever raised again, and
nothing is logged. The connection is private, so a consumer has no way to detect it. We hit
this as passive monitoring silently stopping until the process was restarted.

## What changed

- `ConnectionLost` event on `AdvertisementMonitor`, raised when its connection drops.
- `Dispose` now also closes that connection. Each monitor owns one, so a monitor dropped
  without disposing leaked its socket until finalization.

The library does not attempt recovery: the object cannot be revived in place, so recreating it
is the consumer's decision. The event exists so that decision can be made at all.
